### PR TITLE
Add ESP32 iPixel firmware scaffold

### DIFF
--- a/ipixel/README.md
+++ b/ipixel/README.md
@@ -1,0 +1,63 @@
+# GT7 ESP32 iPixel
+
+Always-on ESP32 firmware for the core Hueflash/Drive experience:
+
+- listens for GT7 telemetry directly from the PS5
+- detects active driving versus pause/idle
+- controls Home Assistant shift and room lights
+- writes current gear and suggested gear to an iPixel-style BLE display
+- exposes a small local config web page
+
+This is the embedded replacement path for `hueflash.py` + `drive.py`. The TUI and Stream Deck integrations stay laptop/host tools and are intentionally not part of this firmware.
+
+## Current Status
+
+This folder contains the first Arduino/PlatformIO firmware scaffold. The GT7 telemetry and Home Assistant pieces are implemented around the same protocol details used by `gt-telem`:
+
+- heartbeat `A` to PS5 UDP port `33739`
+- telemetry listener on UDP port `33740`
+- GT7 Salsa20 key and IV mask
+- current gear from the low nibble of `bits`
+- suggested gear from the high nibble of `bits`
+- rev limit from flag bit 5
+
+The BLE iPixel layer connects by MAC/address and writes to a configurable service/characteristic. The exact iPixel payload format still needs to be confirmed against the real device or the `pypixelcolor` protocol. Until then, the firmware sends a simple template payload such as `G:4|S:2|C:orange`.
+
+## Build
+
+Install PlatformIO, then:
+
+```sh
+cd ipixel/firmware
+pio run
+pio run -t upload
+pio device monitor
+```
+
+## First Run
+
+If no Wi-Fi credentials are saved, the ESP32 starts a setup access point:
+
+```text
+SSID: GT7-iPixel-Setup
+URL:  http://192.168.4.1
+```
+
+Configure:
+
+- Wi-Fi SSID/password
+- PS5 IP
+- Home Assistant URL/token
+- shift light entity
+- comma-separated room light entities
+- iPixel BLE address
+- iPixel service/characteristic UUIDs
+
+## Next Steps
+
+1. Flash and confirm GT7 telemetry packets decrypt on the ESP32.
+2. Use the serial monitor BLE discovery logs to identify the iPixel service and writable characteristic.
+3. Capture/confirm the real iPixel BLE payload format.
+4. Replace the template text payload in `IpixelDisplay` with the real frame/text protocol.
+5. Add OTA updates once the core loop is stable.
+

--- a/ipixel/docs/BLE_PROTOCOL.md
+++ b/ipixel/docs/BLE_PROTOCOL.md
@@ -1,0 +1,30 @@
+# iPixel BLE Protocol Notes
+
+The firmware currently has a BLE transport, not a confirmed iPixel renderer.
+
+Why: the existing Python project does not include `pypixelcolor`, and the exact BLE service, characteristic, and payload format need to be verified on your specific display.
+
+## What The Firmware Can Already Do
+
+- Connect to a configured BLE address.
+- Discover services and characteristics and print them to serial.
+- Write a configurable gear/suggested-gear text payload to the selected characteristic.
+
+## What We Need To Confirm
+
+- iPixel BLE MAC/address.
+- Service UUID.
+- Writable characteristic UUID.
+- Whether writes need response or no-response.
+- Payload format for drawing text or frames.
+
+## Discovery Workflow
+
+1. Flash `ipixel/firmware`.
+2. Open the serial monitor.
+3. Configure the iPixel address in the web UI.
+4. Watch the serial output for discovered services/characteristics.
+5. Put the writable characteristic UUID into the web UI.
+
+Once the UUIDs are known, the remaining work is replacing the simple template payload with the real iPixel frame/text payload.
+

--- a/ipixel/firmware/include/AppConfig.h
+++ b/ipixel/firmware/include/AppConfig.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+struct AppConfig {
+  String wifiSsid;
+  String wifiPassword;
+  String ps5Ip;
+  String haUrl;
+  String haToken;
+  String shiftLightEntity;
+  String roomLightsCsv;
+  uint32_t telemetryTimeoutMs = 1000;
+  uint8_t shiftBrightness = 255;
+  bool ipixelEnabled = true;
+  String ipixelAddress;
+  String ipixelServiceUuid;
+  String ipixelCharacteristicUuid;
+  String ipixelPayloadTemplate = "G:{gear}|S:{suggested}|C:{color}";
+  uint8_t ipixelBrightness = 40;
+  uint32_t displayRefreshMs = 100;
+};
+
+inline String prefGetString(Preferences &prefs, const char *key, const String &fallback = "") {
+  return prefs.getString(key, fallback);
+}
+
+inline void loadConfig(AppConfig &cfg) {
+  Preferences prefs;
+  prefs.begin("gt7ipixel", true);
+  cfg.wifiSsid = prefGetString(prefs, "wifiSsid");
+  cfg.wifiPassword = prefGetString(prefs, "wifiPass");
+  cfg.ps5Ip = prefGetString(prefs, "ps5Ip");
+  cfg.haUrl = prefGetString(prefs, "haUrl");
+  cfg.haToken = prefGetString(prefs, "haToken");
+  cfg.shiftLightEntity = prefGetString(prefs, "shiftEntity");
+  cfg.roomLightsCsv = prefGetString(prefs, "roomLights");
+  cfg.telemetryTimeoutMs = prefs.getUInt("telemTimeout", cfg.telemetryTimeoutMs);
+  cfg.shiftBrightness = prefs.getUChar("shiftBright", cfg.shiftBrightness);
+  cfg.ipixelEnabled = prefs.getBool("ipixelOn", cfg.ipixelEnabled);
+  cfg.ipixelAddress = prefGetString(prefs, "ipixAddr");
+  cfg.ipixelServiceUuid = prefGetString(prefs, "ipixSvc");
+  cfg.ipixelCharacteristicUuid = prefGetString(prefs, "ipixChr");
+  cfg.ipixelPayloadTemplate = prefGetString(prefs, "ipixTpl", cfg.ipixelPayloadTemplate);
+  cfg.ipixelBrightness = prefs.getUChar("ipixBright", cfg.ipixelBrightness);
+  cfg.displayRefreshMs = prefs.getUInt("displayMs", cfg.displayRefreshMs);
+  prefs.end();
+}
+
+inline void saveConfig(const AppConfig &cfg) {
+  Preferences prefs;
+  prefs.begin("gt7ipixel", false);
+  prefs.putString("wifiSsid", cfg.wifiSsid);
+  prefs.putString("wifiPass", cfg.wifiPassword);
+  prefs.putString("ps5Ip", cfg.ps5Ip);
+  prefs.putString("haUrl", cfg.haUrl);
+  prefs.putString("haToken", cfg.haToken);
+  prefs.putString("shiftEntity", cfg.shiftLightEntity);
+  prefs.putString("roomLights", cfg.roomLightsCsv);
+  prefs.putUInt("telemTimeout", cfg.telemetryTimeoutMs);
+  prefs.putUChar("shiftBright", cfg.shiftBrightness);
+  prefs.putBool("ipixelOn", cfg.ipixelEnabled);
+  prefs.putString("ipixAddr", cfg.ipixelAddress);
+  prefs.putString("ipixSvc", cfg.ipixelServiceUuid);
+  prefs.putString("ipixChr", cfg.ipixelCharacteristicUuid);
+  prefs.putString("ipixTpl", cfg.ipixelPayloadTemplate);
+  prefs.putUChar("ipixBright", cfg.ipixelBrightness);
+  prefs.putUInt("displayMs", cfg.displayRefreshMs);
+  prefs.end();
+}
+

--- a/ipixel/firmware/include/Gt7Telemetry.h
+++ b/ipixel/firmware/include/Gt7Telemetry.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <Arduino.h>
+#include <WiFiUdp.h>
+#include <Salsa20.h>
+
+struct Gt7Packet {
+  bool valid = false;
+  float positionX = 0;
+  float positionY = 0;
+  float positionZ = 0;
+  float engineRpm = 0;
+  float speedKph = 0;
+  int32_t packetId = 0;
+  int32_t timeOfDayMs = 0;
+  int16_t minAlertRpm = 0;
+  int16_t maxAlertRpm = 0;
+  int16_t flags = 0;
+  uint8_t bits = 0;
+  uint8_t throttle = 0;
+  uint8_t brake = 0;
+
+  int currentGear() const { return bits & 0x0f; }
+  int suggestedGear() const { return (bits >> 4) & 0x0f; }
+  bool carsOnTrack() const { return flags & (1 << 0); }
+  bool paused() const { return flags & (1 << 1); }
+  bool loading() const { return flags & (1 << 2); }
+  bool revLimit() const { return flags & (1 << 5); }
+};
+
+class Gt7TelemetryClient {
+public:
+  static constexpr uint16_t ReceivePort = 33739;
+  static constexpr uint16_t BindPort = 33740;
+
+  bool begin(const String &ps5Ip) {
+    _ps5Ip = ps5Ip;
+    if (!_udp.begin(BindPort)) {
+      Serial.println("Failed to bind GT7 UDP listener");
+      return false;
+    }
+    _lastHeartbeatMs = 0;
+    Serial.printf("GT7 telemetry listening on UDP %u, heartbeat target %s:%u\n",
+                  BindPort, _ps5Ip.c_str(), ReceivePort);
+    return true;
+  }
+
+  void sendHeartbeatIfDue() {
+    if (_ps5Ip.isEmpty()) {
+      return;
+    }
+    uint32_t now = millis();
+    if (_lastHeartbeatMs != 0 && now - _lastHeartbeatMs < 10000) {
+      return;
+    }
+    _lastHeartbeatMs = now;
+    _udp.beginPacket(_ps5Ip.c_str(), ReceivePort);
+    _udp.write((const uint8_t *)"A", 1);
+    _udp.endPacket();
+  }
+
+  bool readPacket(Gt7Packet &packet) {
+    int packetSize = _udp.parsePacket();
+    if (packetSize <= 0) {
+      return false;
+    }
+    if (packetSize > (int)sizeof(_rxBuffer)) {
+      Serial.printf("Dropping oversized GT7 packet: %d bytes\n", packetSize);
+      while (_udp.available()) {
+        _udp.read();
+      }
+      return false;
+    }
+
+    int read = _udp.read(_rxBuffer, sizeof(_rxBuffer));
+    if (read <= 0) {
+      return false;
+    }
+
+    if (!decrypt(_rxBuffer, read, _plainBuffer)) {
+      return false;
+    }
+
+    if (read < 4 || memcmp(_plainBuffer, "0S7G", 4) != 0) {
+      return false;
+    }
+
+    packet = parseTelemetry(_plainBuffer + 4, read - 4);
+    packet.valid = true;
+    return true;
+  }
+
+private:
+  String _ps5Ip;
+  WiFiUDP _udp;
+  uint32_t _lastHeartbeatMs = 0;
+  uint8_t _rxBuffer[512];
+  uint8_t _plainBuffer[512];
+
+  static uint32_t readU32Le(const uint8_t *buf) {
+    return (uint32_t)buf[0] | ((uint32_t)buf[1] << 8) | ((uint32_t)buf[2] << 16) | ((uint32_t)buf[3] << 24);
+  }
+
+  static int32_t readI32Le(const uint8_t *buf) {
+    return (int32_t)readU32Le(buf);
+  }
+
+  static int16_t readI16Le(const uint8_t *buf) {
+    return (int16_t)((uint16_t)buf[0] | ((uint16_t)buf[1] << 8));
+  }
+
+  static float readFloatLe(const uint8_t *buf) {
+    uint32_t raw = readU32Le(buf);
+    float value;
+    memcpy(&value, &raw, sizeof(value));
+    return value;
+  }
+
+  static float readFloatAdvance(const uint8_t *buf, size_t &offset) {
+    float value = readFloatLe(buf + offset);
+    offset += 4;
+    return value;
+  }
+
+  static int32_t readI32Advance(const uint8_t *buf, size_t &offset) {
+    int32_t value = readI32Le(buf + offset);
+    offset += 4;
+    return value;
+  }
+
+  static int16_t readI16Advance(const uint8_t *buf, size_t &offset) {
+    int16_t value = readI16Le(buf + offset);
+    offset += 2;
+    return value;
+  }
+
+  bool decrypt(const uint8_t *cipherText, size_t len, uint8_t *plainText) {
+    if (len < 0x44) {
+      return false;
+    }
+
+    static const uint8_t key[32] = {
+      'S','i','m','u','l','a','t','o','r',' ','I','n','t','e','r','f',
+      'a','c','e',' ','P','a','c','k','e','t',' ','G','T','7',' ','v'
+    };
+    constexpr uint32_t ivMask = 0xDEADBEAF;
+
+    uint32_t seed = readU32Le(cipherText + 0x40);
+    uint32_t iv = seed ^ ivMask;
+    uint8_t nonce[8] = {
+      (uint8_t)(iv & 0xff),
+      (uint8_t)((iv >> 8) & 0xff),
+      (uint8_t)((iv >> 16) & 0xff),
+      (uint8_t)((iv >> 24) & 0xff),
+      (uint8_t)(seed & 0xff),
+      (uint8_t)((seed >> 8) & 0xff),
+      (uint8_t)((seed >> 16) & 0xff),
+      (uint8_t)((seed >> 24) & 0xff),
+    };
+
+    Salsa20 salsa;
+    salsa.setKey(key, sizeof(key));
+    salsa.setIV(nonce, sizeof(nonce));
+    salsa.decrypt(plainText, cipherText, len);
+    return true;
+  }
+
+  Gt7Packet parseTelemetry(const uint8_t *buf, size_t len) {
+    Gt7Packet p;
+    if (len < 143) {
+      return p;
+    }
+
+    size_t o = 0;
+    p.positionX = readFloatAdvance(buf, o);
+    p.positionY = readFloatAdvance(buf, o);
+    p.positionZ = readFloatAdvance(buf, o);
+    o += 11 * 4; // velocity, rotation, orientation, angular velocity, body height
+    p.engineRpm = readFloatAdvance(buf, o);
+    o += 3 * 4; // iv, fuel_level, fuel_capacity
+    float speedMps = readFloatAdvance(buf, o);
+    p.speedKph = speedMps * 3.6f;
+    o += 8 * 4; // boost, pressure/temp fields, tire temps
+    p.packetId = readI32Advance(buf, o);
+    o += 2 * 2; // current_lap, total_laps
+    o += 2 * 4; // best_lap_time_ms, last_lap_time_ms
+    p.timeOfDayMs = readI32Advance(buf, o);
+    o += 2 * 2; // race_start_pos, total_cars
+    p.minAlertRpm = readI16Advance(buf, o);
+    p.maxAlertRpm = readI16Advance(buf, o);
+    o += 2; // calc_max_speed
+    p.flags = readI16Advance(buf, o);
+    p.bits = buf[o++];
+    p.throttle = buf[o++];
+    p.brake = buf[o++];
+    return p;
+  }
+};

--- a/ipixel/firmware/include/HomeAssistantClient.h
+++ b/ipixel/firmware/include/HomeAssistantClient.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+#include <vector>
+
+struct StoredLightState {
+  String entityId;
+  String state;
+  bool hasBrightness = false;
+  int brightness = 0;
+  bool hasRgb = false;
+  int rgb[3] = {0, 0, 0};
+  bool hasColorTemp = false;
+  int colorTemp = 0;
+};
+
+class HomeAssistantClient {
+public:
+  void configure(const String &baseUrl, const String &token) {
+    _baseUrl = baseUrl;
+    _token = token;
+    _baseUrl.trim();
+    if (_baseUrl.endsWith("/")) {
+      _baseUrl.remove(_baseUrl.length() - 1);
+    }
+  }
+
+  bool ready() const {
+    return !_baseUrl.isEmpty() && !_token.isEmpty();
+  }
+
+  bool turnOff(const String &entityId) {
+    JsonDocument doc;
+    doc["entity_id"] = entityId;
+    return postService("light", "turn_off", doc);
+  }
+
+  bool turnOnRed(const String &entityId, uint8_t brightness) {
+    JsonDocument doc;
+    doc["entity_id"] = entityId;
+    doc["brightness"] = brightness;
+    JsonArray rgb = doc["rgb_color"].to<JsonArray>();
+    rgb.add(255);
+    rgb.add(0);
+    rgb.add(0);
+    return postService("light", "turn_on", doc);
+  }
+
+  bool restoreLight(const StoredLightState &state) {
+    JsonDocument doc;
+    doc["entity_id"] = state.entityId;
+    if (state.state == "off") {
+      return postService("light", "turn_off", doc);
+    }
+
+    if (state.hasBrightness) {
+      doc["brightness"] = state.brightness;
+    }
+    if (state.hasRgb) {
+      JsonArray rgb = doc["rgb_color"].to<JsonArray>();
+      rgb.add(state.rgb[0]);
+      rgb.add(state.rgb[1]);
+      rgb.add(state.rgb[2]);
+    } else if (state.hasColorTemp) {
+      doc["color_temp"] = state.colorTemp;
+    }
+
+    return postService("light", "turn_on", doc);
+  }
+
+  bool fetchLightState(const String &entityId, StoredLightState &state) {
+    if (!ready()) {
+      return false;
+    }
+    HTTPClient http;
+    String url = _baseUrl + "/api/states/" + entityId;
+    http.begin(url);
+    addAuthHeaders(http);
+    int code = http.GET();
+    if (code < 200 || code >= 300) {
+      Serial.printf("HA state fetch failed for %s: HTTP %d\n", entityId.c_str(), code);
+      http.end();
+      return false;
+    }
+
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, http.getString());
+    http.end();
+    if (error) {
+      Serial.printf("HA state JSON parse failed for %s\n", entityId.c_str());
+      return false;
+    }
+
+    state.entityId = entityId;
+    state.state = doc["state"] | "off";
+    JsonVariant attrs = doc["attributes"];
+    if (!attrs.isNull()) {
+      if (!attrs["brightness"].isNull()) {
+        state.hasBrightness = true;
+        state.brightness = attrs["brightness"].as<int>();
+      }
+      if (!attrs["rgb_color"].isNull() && attrs["rgb_color"].size() >= 3) {
+        state.hasRgb = true;
+        state.rgb[0] = attrs["rgb_color"][0].as<int>();
+        state.rgb[1] = attrs["rgb_color"][1].as<int>();
+        state.rgb[2] = attrs["rgb_color"][2].as<int>();
+      }
+      if (!attrs["color_temp"].isNull()) {
+        state.hasColorTemp = true;
+        state.colorTemp = attrs["color_temp"].as<int>();
+      }
+    }
+    return true;
+  }
+
+private:
+  String _baseUrl;
+  String _token;
+
+  void addAuthHeaders(HTTPClient &http) {
+    http.addHeader("Authorization", "Bearer " + _token);
+    http.addHeader("Content-Type", "application/json");
+  }
+
+  bool postService(const char *domain, const char *service, JsonDocument &doc) {
+    if (!ready()) {
+      return false;
+    }
+
+    String body;
+    serializeJson(doc, body);
+
+    HTTPClient http;
+    String url = _baseUrl + "/api/services/" + domain + "/" + service;
+    http.begin(url);
+    addAuthHeaders(http);
+    int code = http.POST(body);
+    bool ok = code >= 200 && code < 300;
+    if (!ok) {
+      Serial.printf("HA service %s/%s failed: HTTP %d\n", domain, service, code);
+    }
+    http.end();
+    return ok;
+  }
+};
+
+inline std::vector<String> splitCsv(const String &csv) {
+  std::vector<String> values;
+  int start = 0;
+  while (start < (int)csv.length()) {
+    int comma = csv.indexOf(',', start);
+    if (comma == -1) {
+      comma = csv.length();
+    }
+    String value = csv.substring(start, comma);
+    value.trim();
+    if (!value.isEmpty()) {
+      values.push_back(value);
+    }
+    start = comma + 1;
+  }
+  return values;
+}
+

--- a/ipixel/firmware/include/IpixelDisplay.h
+++ b/ipixel/firmware/include/IpixelDisplay.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+
+class IpixelDisplay {
+public:
+  void configure(bool enabled,
+                 const String &address,
+                 const String &serviceUuid,
+                 const String &characteristicUuid,
+                 const String &payloadTemplate,
+                 uint8_t brightness,
+                 uint32_t refreshMs) {
+    _enabled = enabled;
+    _address = address;
+    _serviceUuid = serviceUuid;
+    _characteristicUuid = characteristicUuid;
+    _payloadTemplate = payloadTemplate;
+    _brightness = brightness;
+    _refreshMs = refreshMs;
+  }
+
+  void begin() {
+    if (!_enabled) {
+      return;
+    }
+    NimBLEDevice::init("GT7-iPixel");
+    NimBLEDevice::setPower(ESP_PWR_LVL_P9);
+  }
+
+  void loop() {
+    if (!_enabled || connected() || _address.isEmpty()) {
+      return;
+    }
+    uint32_t now = millis();
+    if (now - _lastConnectAttemptMs < 5000) {
+      return;
+    }
+    _lastConnectAttemptMs = now;
+    connect();
+  }
+
+  bool connected() const {
+    return _client && _client->isConnected() && _characteristic;
+  }
+
+  void showGear(int currentGear, int suggestedGear, bool revLimit) {
+    if (!_enabled) {
+      return;
+    }
+    uint32_t now = millis();
+    if (now - _lastWriteMs < _refreshMs) {
+      return;
+    }
+    if (currentGear == _lastGear && suggestedGear == _lastSuggested && revLimit == _lastRevLimit) {
+      return;
+    }
+
+    loop();
+    if (!connected()) {
+      return;
+    }
+
+    _lastWriteMs = now;
+    _lastGear = currentGear;
+    _lastSuggested = suggestedGear;
+    _lastRevLimit = revLimit;
+
+    String color = "white";
+    if (revLimit) {
+      color = "red";
+    } else if (suggestedGear > 0 && suggestedGear < currentGear) {
+      color = "orange";
+    } else if (suggestedGear > currentGear) {
+      color = "blue";
+    } else if (suggestedGear == currentGear && currentGear > 0) {
+      color = "green";
+    }
+
+    String payload = _payloadTemplate;
+    payload.replace("{gear}", formatGear(currentGear));
+    payload.replace("{suggested}", formatGear(suggestedGear));
+    payload.replace("{color}", color);
+    payload.replace("{brightness}", String(_brightness));
+
+    bool ok = _characteristic->writeValue((uint8_t *)payload.c_str(), payload.length(), false);
+    if (!ok) {
+      Serial.println("iPixel BLE write failed");
+    }
+  }
+
+private:
+  bool _enabled = true;
+  String _address;
+  String _serviceUuid;
+  String _characteristicUuid;
+  String _payloadTemplate;
+  uint8_t _brightness = 40;
+  uint32_t _refreshMs = 100;
+  uint32_t _lastConnectAttemptMs = 0;
+  uint32_t _lastWriteMs = 0;
+  int _lastGear = -999;
+  int _lastSuggested = -999;
+  bool _lastRevLimit = false;
+  NimBLEClient *_client = nullptr;
+  NimBLERemoteCharacteristic *_characteristic = nullptr;
+
+  String formatGear(int gear) const {
+    if (gear == 0) {
+      return "N";
+    }
+    if (gear < 0 || gear > 8) {
+      return "--";
+    }
+    return String(gear);
+  }
+
+  void connect() {
+    if (_serviceUuid.isEmpty() || _characteristicUuid.isEmpty()) {
+      Serial.println("iPixel UUIDs not configured yet");
+      return;
+    }
+
+    Serial.printf("Connecting to iPixel BLE device %s\n", _address.c_str());
+    NimBLEAddress address(_address.c_str());
+    _client = NimBLEDevice::createClient();
+    if (!_client->connect(address)) {
+      Serial.println("iPixel BLE connection failed");
+      NimBLEDevice::deleteClient(_client);
+      _client = nullptr;
+      return;
+    }
+
+    Serial.println("iPixel BLE connected; discovering services");
+    for (auto *service : *_client->getServices(true)) {
+      Serial.printf("BLE service: %s\n", service->getUUID().toString().c_str());
+      for (auto *characteristic : *service->getCharacteristics(true)) {
+        Serial.printf("  characteristic: %s props=0x%02x\n",
+                      characteristic->getUUID().toString().c_str(),
+                      characteristic->getProperties());
+      }
+    }
+
+    NimBLERemoteService *service = _client->getService(_serviceUuid.c_str());
+    if (!service) {
+      Serial.println("Configured iPixel service UUID not found");
+      _client->disconnect();
+      return;
+    }
+
+    _characteristic = service->getCharacteristic(_characteristicUuid.c_str());
+    if (!_characteristic) {
+      Serial.println("Configured iPixel characteristic UUID not found");
+      _client->disconnect();
+      return;
+    }
+
+    Serial.println("iPixel BLE characteristic ready");
+  }
+};
+

--- a/ipixel/firmware/platformio.ini
+++ b/ipixel/firmware/platformio.ini
@@ -1,0 +1,13 @@
+[platformio]
+default_envs = esp32dev
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  bblanchon/ArduinoJson
+  h2zero/NimBLE-Arduino
+  rweather/Crypto
+

--- a/ipixel/firmware/src/main.cpp
+++ b/ipixel/firmware/src/main.cpp
@@ -1,0 +1,345 @@
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <WebServer.h>
+#include <WiFi.h>
+
+#include "AppConfig.h"
+#include "Gt7Telemetry.h"
+#include "HomeAssistantClient.h"
+#include "IpixelDisplay.h"
+
+enum class DriveState {
+  Idle,
+  Driving,
+};
+
+AppConfig config;
+WebServer server(80);
+Gt7TelemetryClient gt7;
+HomeAssistantClient ha;
+IpixelDisplay ipixel;
+DriveState driveState = DriveState::Idle;
+Gt7Packet lastPacket;
+uint32_t lastPacketMs = 0;
+uint32_t dataFrozenStartMs = 0;
+bool telemetryStarted = false;
+bool shiftLightActive = false;
+std::vector<StoredLightState> savedRoomStates;
+
+const char *SETUP_AP_SSID = "GT7-iPixel-Setup";
+
+String htmlPage() {
+  return R"HTML(
+<!doctype html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GT7 iPixel Setup</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 760px; margin: 24px auto; padding: 0 16px; background: #111; color: #f4f4f4; }
+    label { display: block; margin-top: 14px; font-weight: 700; }
+    input, textarea { width: 100%; box-sizing: border-box; padding: 10px; margin-top: 6px; background: #1d1d1d; color: #fff; border: 1px solid #555; border-radius: 6px; }
+    button { margin-top: 18px; padding: 10px 14px; border: 0; border-radius: 6px; background: #2e8bff; color: white; font-weight: 700; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    @media (max-width: 640px) { .row { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h1>GT7 iPixel Setup</h1>
+  <form id="cfg">
+    <div class="row">
+      <div><label>Wi-Fi SSID<input name="wifiSsid"></label></div>
+      <div><label>Wi-Fi Password<input name="wifiPassword" type="password"></label></div>
+    </div>
+    <label>PS5 IP<input name="ps5Ip" placeholder="192.168.1.150"></label>
+    <label>Home Assistant URL<input name="haUrl" placeholder="http://homeassistant.local:8123"></label>
+    <label>Home Assistant Token<textarea name="haToken" rows="3"></textarea></label>
+    <label>Shift Light Entity<input name="shiftLightEntity" placeholder="light.hue_iris_1"></label>
+    <label>Room Lights, comma-separated<textarea name="roomLightsCsv" rows="2" placeholder="light.living_room, light.office"></textarea></label>
+    <div class="row">
+      <div><label>Telemetry Timeout (ms)<input name="telemetryTimeoutMs" type="number" min="100"></label></div>
+      <div><label>Shift Brightness (0-255)<input name="shiftBrightness" type="number" min="1" max="255"></label></div>
+    </div>
+    <label>iPixel BLE Address<input name="ipixelAddress" placeholder="aa:bb:cc:dd:ee:ff"></label>
+    <label>iPixel Service UUID<input name="ipixelServiceUuid"></label>
+    <label>iPixel Characteristic UUID<input name="ipixelCharacteristicUuid"></label>
+    <label>iPixel Payload Template<input name="ipixelPayloadTemplate" placeholder="G:{gear}|S:{suggested}|C:{color}"></label>
+    <div class="row">
+      <div><label>iPixel Brightness (0-100)<input name="ipixelBrightness" type="number" min="0" max="100"></label></div>
+      <div><label>Display Refresh (ms)<input name="displayRefreshMs" type="number" min="50"></label></div>
+    </div>
+    <button type="submit">Save & Reboot</button>
+  </form>
+  <script>
+    async function load() {
+      const cfg = await fetch('/api/config').then(r => r.json());
+      for (const [key, value] of Object.entries(cfg)) {
+        const input = document.querySelector(`[name="${key}"]`);
+        if (input) input.value = value ?? '';
+      }
+    }
+    document.getElementById('cfg').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const data = Object.fromEntries(new FormData(event.currentTarget).entries());
+      for (const key of ['telemetryTimeoutMs', 'shiftBrightness', 'ipixelBrightness', 'displayRefreshMs']) data[key] = Number(data[key]);
+      await fetch('/api/config', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data) });
+      document.body.innerHTML = '<h1>Saved</h1><p>The ESP32 is rebooting.</p>';
+    });
+    load();
+  </script>
+</body>
+</html>
+)HTML";
+}
+
+void sendConfigJson() {
+  JsonDocument doc;
+  doc["wifiSsid"] = config.wifiSsid;
+  doc["wifiPassword"] = "";
+  doc["ps5Ip"] = config.ps5Ip;
+  doc["haUrl"] = config.haUrl;
+  doc["haToken"] = "";
+  doc["shiftLightEntity"] = config.shiftLightEntity;
+  doc["roomLightsCsv"] = config.roomLightsCsv;
+  doc["telemetryTimeoutMs"] = config.telemetryTimeoutMs;
+  doc["shiftBrightness"] = config.shiftBrightness;
+  doc["ipixelAddress"] = config.ipixelAddress;
+  doc["ipixelServiceUuid"] = config.ipixelServiceUuid;
+  doc["ipixelCharacteristicUuid"] = config.ipixelCharacteristicUuid;
+  doc["ipixelPayloadTemplate"] = config.ipixelPayloadTemplate;
+  doc["ipixelBrightness"] = config.ipixelBrightness;
+  doc["displayRefreshMs"] = config.displayRefreshMs;
+
+  String body;
+  serializeJson(doc, body);
+  server.send(200, "application/json", body);
+}
+
+void updateConfigFromJson() {
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, server.arg("plain"));
+  if (error) {
+    server.send(400, "application/json", "{\"error\":\"invalid json\"}");
+    return;
+  }
+
+  config.wifiSsid = doc["wifiSsid"] | config.wifiSsid;
+  String newPassword = doc["wifiPassword"] | "";
+  if (!newPassword.isEmpty()) {
+    config.wifiPassword = newPassword;
+  }
+  config.ps5Ip = doc["ps5Ip"] | config.ps5Ip;
+  config.haUrl = doc["haUrl"] | config.haUrl;
+  String newToken = doc["haToken"] | "";
+  if (!newToken.isEmpty()) {
+    config.haToken = newToken;
+  }
+  config.shiftLightEntity = doc["shiftLightEntity"] | config.shiftLightEntity;
+  config.roomLightsCsv = doc["roomLightsCsv"] | config.roomLightsCsv;
+  config.telemetryTimeoutMs = doc["telemetryTimeoutMs"] | config.telemetryTimeoutMs;
+  config.shiftBrightness = doc["shiftBrightness"] | config.shiftBrightness;
+  config.ipixelAddress = doc["ipixelAddress"] | config.ipixelAddress;
+  config.ipixelServiceUuid = doc["ipixelServiceUuid"] | config.ipixelServiceUuid;
+  config.ipixelCharacteristicUuid = doc["ipixelCharacteristicUuid"] | config.ipixelCharacteristicUuid;
+  config.ipixelPayloadTemplate = doc["ipixelPayloadTemplate"] | config.ipixelPayloadTemplate;
+  config.ipixelBrightness = doc["ipixelBrightness"] | config.ipixelBrightness;
+  config.displayRefreshMs = doc["displayRefreshMs"] | config.displayRefreshMs;
+
+  saveConfig(config);
+  server.send(200, "application/json", "{\"ok\":true}");
+  delay(250);
+  ESP.restart();
+}
+
+void startWebServer() {
+  server.on("/", HTTP_GET, []() {
+    server.send(200, "text/html", htmlPage());
+  });
+  server.on("/api/config", HTTP_GET, sendConfigJson);
+  server.on("/api/config", HTTP_POST, updateConfigFromJson);
+  server.begin();
+  Serial.println("Config web server started on port 80");
+}
+
+void connectWifi() {
+  if (config.wifiSsid.isEmpty()) {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(SETUP_AP_SSID);
+    Serial.printf("Setup AP started: %s at %s\n", SETUP_AP_SSID, WiFi.softAPIP().toString().c_str());
+    return;
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(config.wifiSsid.c_str(), config.wifiPassword.c_str());
+  Serial.printf("Connecting to Wi-Fi SSID %s", config.wifiSsid.c_str());
+  uint32_t started = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - started < 20000) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.printf("Wi-Fi connected: %s\n", WiFi.localIP().toString().c_str());
+  } else {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(SETUP_AP_SSID);
+    Serial.printf("Wi-Fi failed; setup AP started: %s at %s\n", SETUP_AP_SSID, WiFi.softAPIP().toString().c_str());
+  }
+}
+
+bool packetDataChanged(const Gt7Packet &packet) {
+  if (!telemetryStarted) {
+    return true;
+  }
+  if (packet.packetId != lastPacket.packetId || packet.timeOfDayMs != lastPacket.timeOfDayMs) {
+    return true;
+  }
+  if (fabs(packet.engineRpm - lastPacket.engineRpm) > 0.1f || fabs(packet.speedKph - lastPacket.speedKph) > 0.1f) {
+    return true;
+  }
+  if (packet.currentGear() != lastPacket.currentGear() || packet.suggestedGear() != lastPacket.suggestedGear()) {
+    return true;
+  }
+  if (fabs(packet.positionX - lastPacket.positionX) > 0.1f ||
+      fabs(packet.positionY - lastPacket.positionY) > 0.1f ||
+      fabs(packet.positionZ - lastPacket.positionZ) > 0.1f) {
+    return true;
+  }
+  return false;
+}
+
+bool inDrivingContext(const Gt7Packet &packet) {
+  return packet.engineRpm > 0 || fabs(packet.speedKph) > 0.1f || packet.currentGear() != 0 || packet.carsOnTrack();
+}
+
+void enterDrivingMode() {
+  if (driveState == DriveState::Driving) {
+    return;
+  }
+  driveState = DriveState::Driving;
+  savedRoomStates.clear();
+  Serial.println("Entering GT7 driving mode");
+
+  if (ha.ready()) {
+    for (const String &entity : splitCsv(config.roomLightsCsv)) {
+      StoredLightState state;
+      if (ha.fetchLightState(entity, state)) {
+        savedRoomStates.push_back(state);
+      }
+      ha.turnOff(entity);
+    }
+  }
+}
+
+void exitDrivingMode() {
+  if (driveState == DriveState::Idle) {
+    return;
+  }
+  driveState = DriveState::Idle;
+  Serial.println("Exiting GT7 driving mode");
+
+  if (shiftLightActive) {
+    shiftLightActive = false;
+    if (ha.ready() && !config.shiftLightEntity.isEmpty()) {
+      ha.turnOff(config.shiftLightEntity);
+    }
+  }
+
+  if (ha.ready()) {
+    for (const StoredLightState &state : savedRoomStates) {
+      ha.restoreLight(state);
+    }
+  }
+  savedRoomStates.clear();
+}
+
+void handleShiftLight(const Gt7Packet &packet) {
+  if (!ha.ready() || config.shiftLightEntity.isEmpty()) {
+    return;
+  }
+
+  if (packet.revLimit() && !shiftLightActive) {
+    shiftLightActive = true;
+    ha.turnOnRed(config.shiftLightEntity, config.shiftBrightness);
+  } else if (!packet.revLimit() && shiftLightActive) {
+    shiftLightActive = false;
+    ha.turnOff(config.shiftLightEntity);
+  }
+}
+
+void handleTelemetryPacket(const Gt7Packet &packet) {
+  uint32_t now = millis();
+  bool changed = packetDataChanged(packet);
+  bool driving = inDrivingContext(packet);
+
+  if (changed) {
+    dataFrozenStartMs = 0;
+  } else if (dataFrozenStartMs == 0) {
+    dataFrozenStartMs = now;
+  }
+
+  if (driving && changed && !packet.paused() && !packet.loading()) {
+    enterDrivingMode();
+    handleShiftLight(packet);
+  } else if (driveState == DriveState::Driving) {
+    bool timedOut = dataFrozenStartMs != 0 && now - dataFrozenStartMs > config.telemetryTimeoutMs;
+    if (!driving || packet.paused() || packet.loading() || timedOut) {
+      exitDrivingMode();
+    }
+  }
+
+  ipixel.showGear(packet.currentGear(), packet.suggestedGear(), packet.revLimit());
+  lastPacket = packet;
+  telemetryStarted = true;
+  lastPacketMs = now;
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(300);
+  Serial.println();
+  Serial.println("GT7 ESP32 iPixel starting");
+
+  loadConfig(config);
+  connectWifi();
+  startWebServer();
+
+  ha.configure(config.haUrl, config.haToken);
+  ipixel.configure(config.ipixelEnabled,
+                   config.ipixelAddress,
+                   config.ipixelServiceUuid,
+                   config.ipixelCharacteristicUuid,
+                   config.ipixelPayloadTemplate,
+                   config.ipixelBrightness,
+                   config.displayRefreshMs);
+  ipixel.begin();
+
+  if (WiFi.status() == WL_CONNECTED && !config.ps5Ip.isEmpty()) {
+    gt7.begin(config.ps5Ip);
+  } else {
+    Serial.println("GT7 telemetry is not configured yet");
+  }
+}
+
+void loop() {
+  server.handleClient();
+  ipixel.loop();
+
+  if (WiFi.status() != WL_CONNECTED || config.ps5Ip.isEmpty()) {
+    delay(10);
+    return;
+  }
+
+  gt7.sendHeartbeatIfDue();
+
+  Gt7Packet packet;
+  if (gt7.readPacket(packet) && packet.valid) {
+    handleTelemetryPacket(packet);
+  }
+
+  if (driveState == DriveState::Driving && lastPacketMs != 0 && millis() - lastPacketMs > config.telemetryTimeoutMs + 1500) {
+    exitDrivingMode();
+  }
+}
+


### PR DESCRIPTION
## Summary
- Adds an `ipixel/` embedded firmware scaffold for the always-on ESP32 direction.
- Targets the core `hueflash.py` + `drive.py` use case: GT7 telemetry, Home Assistant shift light, room light save/off/restore, and iPixel gear display.
- Uses PlatformIO/Arduino ESP32 with NimBLE, ArduinoJson, and Crypto dependencies.

## What is implemented
- GT7 heartbeat `A` sender to PS5 UDP `33739` and telemetry listener on UDP `33740`.
- GT7 Salsa20 decrypt path and packet parsing for current gear, suggested gear, speed, RPM, flags, pause/loading, and rev limit.
- Home Assistant REST client for fetching light state, turning room lights off, restoring prior room light state, and flashing the shift light red at rev limit.
- ESP32 setup AP + local web config page for Wi-Fi, PS5 IP, HA settings, room lights, shift light, iPixel BLE address, UUIDs, and payload template.
- BLE iPixel adapter that connects by address, logs discovered services/characteristics, and writes a configurable gear/suggested-gear payload.
- Docs describing current status and the remaining BLE protocol discovery work.

## Where this is left
- This has not been built locally because PlatformIO is not installed on the dev machine used for the scaffold.
- The iPixel BLE transport is in place, but the real iPixel drawing protocol still needs to be confirmed against the device or `pypixelcolor`.
- First hardware validation should confirm GT7 packet decrypt/parsing over serial, then identify the iPixel writable service/characteristic UUIDs.
- Once UUIDs and payload format are known, replace the temporary template payload (`G:{gear}|S:{suggested}|C:{color}`) with the real current gear + suggested gear renderer.

## Notes
- Existing dirty worktree files were intentionally left out of this PR: `streamdeck_gt7.py`, `config.yaml.bkp`, and the pre-existing `ipixel/plan-gt7Esp32Ipixel.prompt.md`.